### PR TITLE
Feature: Mengubah Rundown

### DIFF
--- a/__tests__/rundown/rundown-table-filled.test.tsx
+++ b/__tests__/rundown/rundown-table-filled.test.tsx
@@ -1,9 +1,12 @@
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { store } from '@/redux/store'
-import '@testing-library/jest-dom'
 import RundownTable from '@/app/event/[eventId]/(eventId)/rundown/RundownTable'
+import { useUpdateRundownMutation } from '@/redux/api/rundownApi'
+import { RundownsDetail } from '@/types/rundown'
+import { toast } from 'react-hot-toast'
+
 
 jest.mock('@/redux/api/rundownApi', () => ({
   useGetEventRundownQuery: jest.fn().mockReturnValue({
@@ -34,10 +37,27 @@ jest.mock('@/redux/api/rundownApi', () => ({
       },
     ],
   }),
+  useUpdateRundownMutation: jest.fn(),
 }))
+
+const mockUpdateRundownData:RundownsDetail = {
+  id: '89f5ded5-3267-4c34-ac6b-a5f345621682',
+  start_time: '14:05:00',
+  end_time: '15:50:00',
+  description: 'isi updated data bener',
+  rundown_order: 2,
+  event: 'bf8d2392-2bf5-4659-8ff4-652e46c21749',
+}
 
 describe('RundownTable', () => {
   test('renders RundownTable component', () => {
+    const mockUseUpdateRundownMutation = jest
+      .fn()
+      .mockResolvedValue({ data: mockUpdateRundownData })
+    ;(useUpdateRundownMutation as jest.Mock).mockReturnValue([
+      mockUseUpdateRundownMutation,
+    ])
+
     render(
       <Provider store={store}>
         <RundownTable eventId="testEventId" />
@@ -45,5 +65,119 @@ describe('RundownTable', () => {
     )
 
     expect(screen.getByTestId('rundown-table')).toBeInTheDocument()
+  })
+})
+
+describe('Rundown Edit', () => {
+  test('renders rundown edit dialog component', () => {
+    const mockUseUpdateRundownMutation = jest
+      .fn()
+      .mockResolvedValue({ data: mockUpdateRundownData })
+    ;(useUpdateRundownMutation as jest.Mock).mockReturnValue([
+      mockUseUpdateRundownMutation,
+    ])
+
+    render(
+      <Provider store={store}>
+        <RundownTable eventId="testEventId" />
+      </Provider>
+    )
+
+    act(() => {
+      const buttonEdit = screen.getByTestId('rundown-2-edit')
+      fireEvent.click(buttonEdit)
+    })
+    expect(screen.getByTestId('edit-rundown-dialog')).toBeInTheDocument()
+
+    const buttonClose = screen.getByTestId('close-form')
+    fireEvent.click(buttonClose)
+  })
+
+  test('update rundown correctly', async () => {
+    const mockUseUpdateRundownMutation = jest
+      .fn()
+      .mockResolvedValue({ data: mockUpdateRundownData })
+    ;(useUpdateRundownMutation as jest.Mock).mockReturnValue([
+      mockUseUpdateRundownMutation,
+    ])
+
+    render(
+      <Provider store={store}>
+        <RundownTable eventId="testEventId" />
+      </Provider>
+    )
+
+    act(() => {
+      const buttonEdit = screen.getByTestId('rundown-2-edit')
+      fireEvent.click(buttonEdit)
+    })
+    fireEvent.change(screen.getByTestId('description-input'), {
+      target: { value: 'isi updated data bener' },
+    })
+    fireEvent.change(screen.getByTestId('start-time-input'), {
+      target: { value: '14:05:00' },
+    })
+    fireEvent.change(screen.getByTestId('end-time-input'), {
+      target: { value: '15:50:00' },
+    })
+    const buttonSubmit = screen.getByTestId('button-submit')
+    fireEvent.click(buttonSubmit)
+    await waitFor(() =>
+      expect(mockUseUpdateRundownMutation).toHaveBeenCalledTimes(1)
+    )
+  })
+
+  test('display update rundown error correctly', async () => {
+    jest.spyOn(toast, 'error').mockImplementation(jest.fn())
+
+    const mockUseUpdateRundownMutation = jest
+      .fn()
+      .mockResolvedValue({ error: {data: {"message":"Invalid rundown data"}} })
+    ;(useUpdateRundownMutation as jest.Mock).mockReturnValue([
+      mockUseUpdateRundownMutation,
+    ])
+
+    render(
+      <Provider store={store}>
+        <RundownTable eventId="testEventId" />
+      </Provider>
+    )
+
+    act(() => {
+      const buttonEdit = screen.getByTestId('rundown-2-edit')
+      fireEvent.click(buttonEdit)
+    })
+    const buttonSubmit = screen.getByTestId('button-submit')
+    fireEvent.click(buttonSubmit)
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Invalid rundown data')
+    })
+  })
+
+  test('display unknown error correctly', async () => {
+    jest.spyOn(toast, 'error').mockImplementation(jest.fn())
+
+    const mockUseUpdateRundownMutation = jest
+      .fn()
+      .mockResolvedValue({ error: {} })
+    ;(useUpdateRundownMutation as jest.Mock).mockReturnValue([
+      mockUseUpdateRundownMutation,
+    ])
+
+    render(
+      <Provider store={store}>
+        <RundownTable eventId="testEventId" />
+      </Provider>
+    )
+
+    act(() => {
+      const buttonEdit = screen.getByTestId('rundown-2-edit')
+      fireEvent.click(buttonEdit)
+    })
+    const buttonSubmit = screen.getByTestId('button-submit')
+    fireEvent.click(buttonSubmit)
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Unknown error!')
+    })
   })
 })

--- a/src/app/event/[eventId]/(eventId)/rundown/CreateRundownButton.tsx
+++ b/src/app/event/[eventId]/(eventId)/rundown/CreateRundownButton.tsx
@@ -8,11 +8,13 @@ export const CreateRundownButton = () => {
   const pathname = usePathname()
 
   return (
-    <div className="flex flex-col gap-8 px-5 py-3 lg:px-10 lg:py-6 border border-teal-600 rounded-xl">
-      <div className="flex flex-row gap-3">
-        <i className="i-ph-list-checks-light size-6 text-gray-950" />
-        <p>No rundowns created yet</p>
-      </div>
+    <div className="flex flex-col gap-8 px-5 py-3 lg:px-10 lg:py-6">
+      <p
+          data-testid="no-rundown-text"
+          className="text-lg text-md text-teal-600 font-bold"
+        >
+          Your event does not have a schedule yet! Create one now!
+        </p>
       <Link href={`${pathname}/create-rundown`} className="w-full">
         <Button
           variant={'ghost'}

--- a/src/app/event/[eventId]/(eventId)/rundown/EditRundownDialog.tsx
+++ b/src/app/event/[eventId]/(eventId)/rundown/EditRundownDialog.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useUpdateRundownMutation } from '@/redux/api/rundownApi'
+import { Input } from '@/components/elements/Forms/input'
+import { Box } from '@mui/material'
+import { Button } from '@/components/elements/Button'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { FormDialog, FormDialogActions } from '@/components/elements/Dialog'
+import { useEffect } from 'react'
+import toast from 'react-hot-toast'
+
+type UpdateRundownFormType = {
+  description: string
+  start_time: string
+  end_time: string
+}
+
+interface Props {
+  readonly openForm: boolean
+  readonly onClose: () => void
+  readonly prevDesc: string
+  readonly rundownId: string
+  readonly prevStartTime: string
+  readonly prevEndTime: string
+}
+
+export default function EditRundownDialog({
+  openForm,
+  onClose,
+  prevDesc,
+  rundownId,
+  prevStartTime,
+  prevEndTime,
+}: Props) {
+  const defaultValues: UpdateRundownFormType = {
+    description: prevDesc,
+    start_time: prevStartTime,
+    end_time: prevEndTime,
+  }
+
+  const [updateRundown] = useUpdateRundownMutation()
+
+  const methods = useForm<UpdateRundownFormType>({
+    defaultValues: defaultValues,
+  })
+  const { control, handleSubmit, reset, setValue } = methods
+
+  useEffect(() => {
+    setValue('description', prevDesc)
+    setValue('start_time', prevStartTime)
+    setValue('end_time', prevEndTime)
+  }, [setValue, prevStartTime, prevDesc, prevEndTime])
+
+  const editTaskStep = async (id: string, changes: UpdateRundownFormType) => {
+    await updateRundown({ id, changes }).then((res) => {
+      if (res) {
+        if ('data' in res) {
+          onClose()
+          reset()
+        } else if ('data' in res.error) {
+          const errorData = res.error.data as { message: string }
+          toast.error(errorData.message)
+        } else {
+          toast.error('Unknown error!')
+        }
+      }
+    })
+  }
+
+  const onSubmit: SubmitHandler<UpdateRundownFormType> = async (data) => {
+    const description = data.description
+    const start_time = data.start_time
+    const end_time = data.end_time
+    editTaskStep(rundownId, {
+      description,
+      start_time,
+      end_time,
+    })
+  }
+
+  return (
+    <Box>
+      <FormDialog
+        open={openForm}
+        onClose={onClose}
+        data-testid="edit-rundown-dialog"
+        title="Edit Rundown"
+      >
+        <FormDialogActions>
+          <div className="flex flex-col gap-3" style={{ flex: 1 }}>
+            <form
+              className="flex flex-col gap-3"
+              onSubmit={handleSubmit(onSubmit)}
+              data-testid="edit-rundown-form"
+            >
+              <Input
+                control={control}
+                name="description"
+                required
+                placeholder="Enter Activity's Description"
+                data-testid="description-input"
+              />
+              <Input
+                control={control}
+                name="start_time"
+                required
+                type="time"
+                placeholder="Enter Activity's Start Time"
+                data-testid="start-time-input"
+              />
+              <Input
+                control={control}
+                name="end_time"
+                required
+                type="time"
+                placeholder="Enter Activity's End Time"
+                data-testid="end-time-input"
+              />
+              <Button type="submit" data-testid="button-submit">
+                Edit Rundown
+              </Button>
+            </form>
+            <Button
+              variant={'secondary'}
+              data-testid="close-form"
+              onClick={onClose}
+            >
+              Close
+            </Button>
+          </div>
+        </FormDialogActions>
+      </FormDialog>
+    </Box>
+  )
+}

--- a/src/app/event/[eventId]/(eventId)/rundown/EventRundown.tsx
+++ b/src/app/event/[eventId]/(eventId)/rundown/EventRundown.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mui/material'
-import { CreateRundownButton } from './CreateRundownButton'
 import React from 'react'
 import RundownTable from './RundownTable'
 
@@ -11,7 +10,6 @@ export const Rundown = ({ eventId }: EventRundownProps) => {
   return (
     <Box>
       <RundownTable eventId={eventId} />
-      <CreateRundownButton data-testid="create-rundown-button" />
     </Box>
   )
 }

--- a/src/app/event/[eventId]/(eventId)/rundown/RundownTable.tsx
+++ b/src/app/event/[eventId]/(eventId)/rundown/RundownTable.tsx
@@ -1,7 +1,7 @@
 import { useGetEventRundownQuery } from '@/redux/api/rundownApi'
 import { CreateRundownButton } from './CreateRundownButton'
 import { Button } from '@/components/elements/Button'
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import EditRundownDialog from './EditRundownDialog'
 
 interface RundownTableProps {

--- a/src/app/event/[eventId]/(eventId)/rundown/RundownTable.tsx
+++ b/src/app/event/[eventId]/(eventId)/rundown/RundownTable.tsx
@@ -1,4 +1,5 @@
 import { useGetEventRundownQuery } from '@/redux/api/rundownApi'
+import { CreateRundownButton } from './CreateRundownButton'
 import React from 'react'
 
 interface RundownTableProps {
@@ -10,12 +11,7 @@ export const RundownTable = ({ eventId }: RundownTableProps) => {
   return (
     <div className="overflow-x-auto mt-2 mb-4">
       {eventRundown.length == 0 ? (
-        <p
-          data-testid="no-rundown-text"
-          className="text-lg text-md text-teal-600 font-bold"
-        >
-          Your event does not have a schedule yet! Create one now!
-        </p>
+        <CreateRundownButton data-testid="create-rundown-button" />
       ) : (
         <table
           data-testid="rundown-table"

--- a/src/app/event/[eventId]/(eventId)/rundown/RundownTable.tsx
+++ b/src/app/event/[eventId]/(eventId)/rundown/RundownTable.tsx
@@ -1,6 +1,8 @@
 import { useGetEventRundownQuery } from '@/redux/api/rundownApi'
 import { CreateRundownButton } from './CreateRundownButton'
-import React from 'react'
+import { Button } from '@/components/elements/Button'
+import React, { useState, useEffect } from 'react'
+import EditRundownDialog from './EditRundownDialog'
 
 interface RundownTableProps {
   eventId: string
@@ -8,32 +10,72 @@ interface RundownTableProps {
 
 export const RundownTable = ({ eventId }: RundownTableProps) => {
   const { data: eventRundown = [] } = useGetEventRundownQuery(eventId)
+  const [openPrompt, setOpenPrompt] = useState(false)
+  const [description, setDescription] = useState('')
+  const [startTime, setStartTime] = useState('')
+  const [endTime, setEndTime] = useState('')
+  const [rundownId, setRundownId] = useState('')
+
+  const handleClosePopup = () => {
+    setOpenPrompt(false)
+  }
+
+  const handleOpenPopup = () => {
+    setOpenPrompt(true)
+  }
+
   return (
     <div className="overflow-x-auto mt-2 mb-4">
       {eventRundown.length == 0 ? (
         <CreateRundownButton data-testid="create-rundown-button" />
       ) : (
-        <table
-          data-testid="rundown-table"
-          className="w-full table-auto rounded-lg overflow-hidden"
-        >
-          <thead>
-            <tr className="bg-teal-500 text-teal-50">
-              <th className="border px-4 py-2">Start Time</th>
-              <th className="border px-4 py-2">End Time</th>
-              <th className="border px-4 py-2">Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            {eventRundown.map((rundown) => (
-              <tr key={rundown.id}>
-                <td className="border px-4 py-2">{rundown.start_time}</td>
-                <td className="border px-4 py-2">{rundown.end_time}</td>
-                <td className="border px-4 py-2">{rundown.description}</td>
+        <div>
+          <table
+            data-testid="rundown-table"
+            className="w-full table-auto rounded-lg overflow-hidden"
+          >
+            <thead>
+              <tr className="bg-teal-500 text-teal-50">
+                <th className="border px-4 py-2">Start Time</th>
+                <th className="border px-4 py-2">End Time</th>
+                <th className="border px-4 py-2">Description</th>
+                <th className="border px-4 py-2">Modify</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {eventRundown.map((rundown) => (
+                <tr key={rundown.id}>
+                  <td className="border px-4 py-2">{rundown.start_time}</td>
+                  <td className="border px-4 py-2">{rundown.end_time}</td>
+                  <td className="border px-4 py-2">{rundown.description}</td>
+                  <td className="border px-4 py-2">
+                    <Button
+                      variant="primary"
+                      data-testid={`rundown-${rundown.rundown_order}-edit`}
+                      onClick={() => {
+                        setRundownId(rundown.id)
+                        setDescription(rundown.description)
+                        setStartTime(rundown.start_time)
+                        setEndTime(rundown.end_time)
+                        handleOpenPopup()
+                      }}
+                    >
+                      Edit
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <EditRundownDialog
+            openForm={openPrompt}
+            onClose={handleClosePopup}
+            prevDesc={description}
+            prevStartTime={startTime}
+            prevEndTime={endTime}
+            rundownId={rundownId}
+          />
+        </div>
       )}
     </div>
   )

--- a/src/redux/api/rundownApi.ts
+++ b/src/redux/api/rundownApi.ts
@@ -2,6 +2,7 @@ import {
   CreateRundownsRequest,
   CreateRundownsResponse,
   RundownsDetail,
+  EditRundownRequest
 } from '@/types/rundown'
 import { baseApi } from './baseApi'
 
@@ -30,8 +31,21 @@ export const rundownApi = baseApi.injectEndpoints({
           ? result.map(({ id }) => ({ type: 'Rundown', id: id }))
           : [{ type: 'Rundown' }],
     }),
+    updateRundown: builder.mutation<
+    RundownsDetail,
+      { id: string; changes: EditRundownRequest }
+    >({
+      query: ({ id, changes }) => ({
+        url: `/rundowns/${id}`,
+        method: 'PATCH',
+        body: changes,
+      }),
+      invalidatesTags: (result) => [{ type: 'Rundown', id: result?.id }],
+    }),
   }),
 })
 
-export const { useCreateRundownManuallyMutation, useGetEventRundownQuery } =
-  rundownApi
+export const { 
+  useCreateRundownManuallyMutation, 
+  useGetEventRundownQuery,
+  useUpdateRundownMutation } = rundownApi

--- a/src/types/rundown.ts
+++ b/src/types/rundown.ts
@@ -14,3 +14,9 @@ export type CreateRundownsRequest = {
 }
 
 export type CreateRundownsResponse = RundownsDetail[]
+
+export type EditRundownRequest = {
+  description: string
+  start_time: string
+  end_time: string
+}


### PR DESCRIPTION
What changes/added:
- Fix layout of rundown parts in event detail page
- Add update rundown feature along with its testing

Page preview:
-) New looks of rundown section when there's no rundown
![image](https://github.com/RevelioStartup/revelio-fe/assets/88031010/e7404592-8b94-4b16-9721-62fd88e25615)

-) New looks of rundown section when there's rundown
![image](https://github.com/RevelioStartup/revelio-fe/assets/88031010/80b059f3-06de-4c35-aa6d-3aa5521a30d4)

-) Rundown edit dialog
![image](https://github.com/RevelioStartup/revelio-fe/assets/88031010/802dbcda-e116-446d-b941-bf1c3b93d473)
