### PR TITLE
Fix loading state on package screen

### DIFF
--- a/__tests__/package/package-list-free.test.tsx
+++ b/__tests__/package/package-list-free.test.tsx
@@ -4,7 +4,6 @@ import '@testing-library/jest-dom'
 import PackageList from '@/app/package/page'
 import { useCreateTransactionMutation } from '@/redux/api/paymentApi'
 
-// Mock data
 const premium_package = {
   name: 'Premium Package',
   price: 5000,
@@ -15,7 +14,6 @@ const premium_package = {
   ai_assistant: true,
 }
 
-// Mock hooks
 jest.mock('@/redux/api/packageApi', () => ({
   useGetPackageDetailQuery: jest.fn((id) => {
     if (id === 1) {

--- a/__tests__/package/package-list-free.test.tsx
+++ b/__tests__/package/package-list-free.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import PackageList from '@/app/package/page'
 import { useCreateTransactionMutation } from '@/redux/api/paymentApi'
 
+// Mock data
 const premium_package = {
   name: 'Premium Package',
   price: 5000,
@@ -13,6 +14,8 @@ const premium_package = {
   event_rundown: true,
   ai_assistant: true,
 }
+
+// Mock hooks
 jest.mock('@/redux/api/packageApi', () => ({
   useGetPackageDetailQuery: jest.fn((id) => {
     if (id === 1) {
@@ -26,14 +29,15 @@ jest.mock('@/redux/api/packageApi', () => ({
           event_rundown: false,
           ai_assistant: false,
         },
+        isLoading: false,
       }
     } else if (id === 2) {
       return {
         data: premium_package,
+        isLoading: false,
       }
     }
-
-    return { data: null }
+    return { data: null, isLoading: true }
   }),
 }))
 
@@ -42,7 +46,7 @@ jest.mock('@/redux/api/paymentApi', () => ({
 }))
 
 jest.mock('@/redux/api/subscriptionApi', () => ({
-  useGetLatestSubscriptionQuery: jest.fn((id) => ({
+  useGetLatestSubscriptionQuery: jest.fn(() => ({
     data: {
       id: 1,
       plan: { id: 1, name: 'FREE' },
@@ -51,10 +55,15 @@ jest.mock('@/redux/api/subscriptionApi', () => ({
       user: 1,
       is_active: false,
     },
+    isLoading: false,
   })),
 }))
 
 describe('PackageList component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('renders correctly for free user', () => {
     const createTransactionMock = jest.fn()
     ;(useCreateTransactionMutation as jest.Mock).mockReturnValue([
@@ -64,6 +73,7 @@ describe('PackageList component', () => {
         isLoading: false,
       },
     ])
+
     const { getByTestId, queryByTestId } = render(<PackageList />)
     const packageDetail = getByTestId('package-detail')
     expect(packageDetail).toBeInTheDocument()
@@ -72,5 +82,35 @@ describe('PackageList component', () => {
     expect(queryByTestId('subscribed-plan')).not.toBeInTheDocument()
     fireEvent.click(subscribeButton)
     expect(createTransactionMock).toHaveBeenCalled()
+  })
+
+  it('displays Loader when data is loading', () => {
+    const useGetPackageDetailQuery = require('@/redux/api/packageApi').useGetPackageDetailQuery
+    const useGetLatestSubscriptionQuery = require('@/redux/api/subscriptionApi').useGetLatestSubscriptionQuery
+
+    useGetPackageDetailQuery.mockReturnValue({ data: null, isLoading: true })
+    useGetLatestSubscriptionQuery.mockReturnValue({ data: null, isLoading: true })
+    ;(useCreateTransactionMutation as jest.Mock).mockReturnValue([jest.fn(), { data: null, isLoading: false }])
+
+    render(<PackageList />)
+    expect(screen.getByTestId('loader')).toBeInTheDocument()
+  })
+
+  it('does not display Loader when data is loaded', () => {
+    const useGetPackageDetailQuery = require('@/redux/api/packageApi').useGetPackageDetailQuery
+    const useGetLatestSubscriptionQuery = require('@/redux/api/subscriptionApi').useGetLatestSubscriptionQuery
+
+    useGetPackageDetailQuery.mockReturnValue({
+      data: { id: 'free', event_planner: true } as any,
+      isLoading: false,
+    })
+    useGetLatestSubscriptionQuery.mockReturnValue({
+      data: { is_active: false, end_date: '2023-12-31' } as any,
+      isLoading: false,
+    })
+    ;(useCreateTransactionMutation as jest.Mock).mockReturnValue([jest.fn(), { data: null, isLoading: false }])
+
+    render(<PackageList />)
+    expect(screen.queryByTestId('loader')).not.toBeInTheDocument()
   })
 })

--- a/__tests__/package/package-list-free.test.tsx
+++ b/__tests__/package/package-list-free.test.tsx
@@ -85,20 +85,30 @@ describe('PackageList component', () => {
   })
 
   it('displays Loader when data is loading', () => {
-    const useGetPackageDetailQuery = require('@/redux/api/packageApi').useGetPackageDetailQuery
-    const useGetLatestSubscriptionQuery = require('@/redux/api/subscriptionApi').useGetLatestSubscriptionQuery
+    const useGetPackageDetailQuery =
+      require('@/redux/api/packageApi').useGetPackageDetailQuery
+    const useGetLatestSubscriptionQuery =
+      require('@/redux/api/subscriptionApi').useGetLatestSubscriptionQuery
 
     useGetPackageDetailQuery.mockReturnValue({ data: null, isLoading: true })
-    useGetLatestSubscriptionQuery.mockReturnValue({ data: null, isLoading: true })
-    ;(useCreateTransactionMutation as jest.Mock).mockReturnValue([jest.fn(), { data: null, isLoading: false }])
+    useGetLatestSubscriptionQuery.mockReturnValue({
+      data: null,
+      isLoading: true,
+    })
+    ;(useCreateTransactionMutation as jest.Mock).mockReturnValue([
+      jest.fn(),
+      { data: null, isLoading: false },
+    ])
 
     render(<PackageList />)
     expect(screen.getByTestId('loader')).toBeInTheDocument()
   })
 
   it('does not display Loader when data is loaded', () => {
-    const useGetPackageDetailQuery = require('@/redux/api/packageApi').useGetPackageDetailQuery
-    const useGetLatestSubscriptionQuery = require('@/redux/api/subscriptionApi').useGetLatestSubscriptionQuery
+    const useGetPackageDetailQuery =
+      require('@/redux/api/packageApi').useGetPackageDetailQuery
+    const useGetLatestSubscriptionQuery =
+      require('@/redux/api/subscriptionApi').useGetLatestSubscriptionQuery
 
     useGetPackageDetailQuery.mockReturnValue({
       data: { id: 'free', event_planner: true } as any,
@@ -108,7 +118,10 @@ describe('PackageList component', () => {
       data: { is_active: false, end_date: '2023-12-31' } as any,
       isLoading: false,
     })
-    ;(useCreateTransactionMutation as jest.Mock).mockReturnValue([jest.fn(), { data: null, isLoading: false }])
+    ;(useCreateTransactionMutation as jest.Mock).mockReturnValue([
+      jest.fn(),
+      { data: null, isLoading: false },
+    ])
 
     render(<PackageList />)
     expect(screen.queryByTestId('loader')).not.toBeInTheDocument()

--- a/src/app/package/page.tsx
+++ b/src/app/package/page.tsx
@@ -21,13 +21,22 @@ import { Button } from '@/components/elements/Button'
 import { useEffect } from 'react'
 
 export default function PackageList() {
-  const { data: free_package = {} as PackageDetailResponse } =
-    useGetPackageDetailQuery(PACKAGE['free'])
-  const { data: premium_package = {} as PackageDetailResponse } =
-    useGetPackageDetailQuery(PACKAGE['premium'])
-  const { data: latest_subscription = {} as LatestSubscriptionResponse } =
-    useGetLatestSubscriptionQuery()
-  const [createTransaction, { data, isLoading }] =
+  const {
+    data: free_package = {} as PackageDetailResponse,
+    isLoading: isLoadingFreePackage,
+  } = useGetPackageDetailQuery(PACKAGE['free'])
+
+  const {
+    data: premium_package = {} as PackageDetailResponse,
+    isLoading: isLoadingPremiumPackage,
+  } = useGetPackageDetailQuery(PACKAGE['premium'])
+
+  const {
+    data: latest_subscription = {} as LatestSubscriptionResponse,
+    isLoading: isLoadingLatestSubscription,
+  } = useGetLatestSubscriptionQuery()
+
+  const [createTransaction, { data, isLoading: isLoadingCreateTransaction }] =
     useCreateTransactionMutation()
 
   const handleCreateTransaction = async () => {
@@ -46,7 +55,14 @@ export default function PackageList() {
     }
   }, [data])
 
-  return (
+  return isLoadingFreePackage ||
+    isLoadingPremiumPackage ||
+    isLoadingLatestSubscription ||
+    !free_package ||
+    !premium_package ||
+    !latest_subscription ? (
+    <Loader />
+  ) : (
     <Box data-testid="package-detail" className="m-2 flex flex-col">
       <Box className="flex flex-col items-center justify-center">
         <p className="text-4xl font-bold mt-4">Revelio</p>
@@ -125,7 +141,7 @@ export default function PackageList() {
                       <Button
                         data-testid="choose-plan-button"
                         onClick={handleCreateTransaction}
-                        loading={isLoading}
+                        loading={isLoadingCreateTransaction}
                         className="bg-white text-teal-600 border border-teal-600 rounded-2xl py-4 px-6 text-sm"
                       >
                         Choose Plan ({formatRupiah(premium_package.price)})
@@ -147,5 +163,13 @@ export default function PackageList() {
         </TableContainer>
       </Box>
     </Box>
+  )
+}
+
+function Loader() {
+  return (
+    <div className="flex flex-col justify-center items-center min-h-[90vh]">
+      <div data-testid="loader" className="loader"></div>
+    </div>
   )
 }


### PR DESCRIPTION
**Changes:**

Previously, the package screen lacked a loading state, which sometimes caused premium users to see the promotional button meant for free users instead of their subscription end date. This issue occurred because the screen would display default content while loading the user-specific information. 

To resolve this, I have implemented a proper loading state for the package screen. Now, when a premium user accesses the page, it correctly displays their subscription end date without showing the promotional content for free users. This ensures a seamless and accurate user experience for our premium members.